### PR TITLE
Remove direct Buffer usages in library

### DIFF
--- a/src/buffers.ts
+++ b/src/buffers.ts
@@ -1,5 +1,5 @@
 // Concatenate Buffers (compatible with TypedArrays and DataViews)
-export const concatBuffers = (...inBuffers: ArrayBufferView[]): Buffer => {
+export const concatBuffers = (...inBuffers: ArrayBufferView[]): Uint8Array => {
   // Allocate byte array equal to the cumulative size of input buffers.
   const concatBufLength: number = inBuffers.reduce(
     (sumLength, buff) => sumLength + buff.byteLength,
@@ -20,7 +20,7 @@ export const concatBuffers = (...inBuffers: ArrayBufferView[]): Buffer => {
     offset += buf.byteLength;
   });
 
-  return Buffer.from(concatBuf);
+  return concatBuf;
 };
 
 // Constants storing the size of a uint64 value.
@@ -29,22 +29,22 @@ const BITS_PER_BYTE = 8;
 const UINT64_SIZE_BITS = UINT64_SIZE_BYTES * BITS_PER_BYTE;
 
 // Returns an 8-byte buffer representing a uint64 value.
-export const bufferFromUInt64 = (uint64Value: number): Buffer => {
+export const bufferFromUInt64 = (uint64Value: number): Uint8Array => {
   const uint64Buf = new ArrayBuffer(UINT64_SIZE_BYTES);
   const uint64DataView = new DataView(uint64Buf);
 
   // We write the value into into the buffer in big-endian format. This is architecture-agnostic
   // and just means we have to read the data back in the same format.
   uint64DataView.setBigUint64(0, BigInt(uint64Value), false); // Big endian.
-  return Buffer.from(uint64DataView.buffer);
+  return new Uint8Array(uint64Buf);
 };
 
 // Reads a uint64 integer value from the buffer, starting at the given offset.
 // Returns the (uint64Value, endOffset) as a tuple.
-export const uint64FromBuffer = (inputBuffer: Buffer, startOffset: number): [number, number] => {
+export const uint64FromBuffer = (input: Uint8Array, startOffset: number): [number, number] => {
   // Create a new buffer containing a copy of the bytes to read.
   const endOffset = startOffset + UINT64_SIZE_BYTES;
-  const uint64Buf = inputBuffer.slice(startOffset, endOffset);
+  const uint64Buf = input.slice(startOffset, endOffset);
   const uint64DataView = new DataView(uint64Buf.buffer, uint64Buf.byteOffset, UINT64_SIZE_BYTES);
 
   // Read the integer from the buffer in big-endian because that is the format used to write it.

--- a/src/buffers.ts
+++ b/src/buffers.ts
@@ -54,3 +54,10 @@ export const uint64FromBuffer = (input: Uint8Array, startOffset: number): [numbe
   );
   return [uint64Value, endOffset];
 };
+
+/**
+ * Checks whether the two Uint8Arrays contain the same data. (same length and same bytes)
+ */
+export const buffersEqual = (a: Uint8Array, b: Uint8Array): boolean => {
+  return a.byteLength === b.byteLength && a.every((byte, i) => byte === b[i]);
+};

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -9,10 +9,8 @@ const SHA1 = 'sha1';
  * NOTE: This is not a cryptographic hash; Useful for obtaining the hexstring hash of
  * encrypted file contents when uploading to the cloud for integrity checks.
  *
- * @param {Buffer} data - Data to hash
- * @param {BufferEncoding} encoding - Optional param to define the string encoding of output. (Ex: 'hex')
- * @returns {Buffer | BufferEncoding} The hash encoded with the given encoding. If no encoding given,
- * the binary buffer is returned.
+ * @param {Uint8Array} data - Data to hash
+ * @returns {Uint8Array} Binary hash
  */
 export function md5Hash(data: Uint8Array): string {
   // In the browser, createHash uses the hash-base library, which uses Buffer.isBuffer() to check for a _isBuffer prop.
@@ -27,19 +25,11 @@ export function md5Hash(data: Uint8Array): string {
 /**
  * Utility function to create SHA256 hashes of data.
  *
- * @param {Buffer} data - Data to hash
- * @param {BufferEncoding} encoding - Optional param to define the string encoding of output. (Ex: 'hex')
- * @returns {Buffer | string} The hash encoded with the given encoding. If no encoding given,
- * the binary buffer is returned.
+ * @param {Uint8Array} data - Data to hash
+ * @returns {Uint8Array} Binary hash
  */
-export function sha256Hash(data: Buffer): Buffer;
-export function sha256Hash(data: Buffer, encoding: BufferEncoding): string;
-export function sha256Hash(data: Buffer, encoding?: BufferEncoding) {
-  if (encoding) {
-    return webcrypto.createHash('sha256').update(data).digest(encoding);
-  } else {
-    return webcrypto.createHash('sha256').update(data).digest();
-  }
+export function sha256Hash(data: Uint8Array): Uint8Array {
+  return webcrypto.createHash('sha256').update(data).digest();
 }
 
 export function csprng(lengthInBytes: number): Uint8Array {
@@ -56,7 +46,11 @@ export function csprng(lengthInBytes: number): Uint8Array {
   return webcrypto.randomBytes(lengthInBytes);
 }
 
-export function aes256gcmEncrypt(plaintext: Buffer, dataKey: Buffer, initializationVector: Buffer) {
+export function aes256gcmEncrypt(
+  plaintext: Uint8Array,
+  dataKey: Uint8Array,
+  initializationVector: Uint8Array,
+) {
   const cipher = webcrypto.createCipheriv(AES_256_GCM, dataKey, initializationVector);
   const ciphertext = concatBuffers(cipher.update(plaintext), cipher.final());
   const authenticationTag = cipher.getAuthTag();

--- a/src/engines/x0.ts
+++ b/src/engines/x0.ts
@@ -109,8 +109,8 @@ export class Encryption {
    *
    * @param plaintext - The plaintext data to encrypt.
    * @param {EncryptConfig} config - An object to configure encryption.
-   *   * wrapperKey - (Buffer) The wrapper key (RSA public key in PEM format).
-   *   * wrapperKeyId - (Buffer) The metadata ID of the RSA public key.
+   *   * wrapperKey - (string) The wrapper key (RSA public key in PEM format).
+   *   * wrapperKeyId - (Uint8Array) The metadata ID of the RSA public key.
    */
   constructor(plaintext: Uint8Array, config: EncryptConfig) {
     this._plaintext = plaintext;
@@ -123,15 +123,15 @@ export class Encryption {
    *
    *     cryptoVersionBuf (UInt16BE)
    *     || wrapperKeyIdLengthInBytes (BigUint64)
-   *     || wrapperKeyId (Buffer)
+   *     || wrapperKeyId (Uint8Array)
    *     || encryptedDataKeyLengthInBytes (BigUint64)
-   *     || encryptedDataKey (Buffer)
-   *     || initializationVector (buffer) (12 bytes)
+   *     || encryptedDataKey (Uint8Array)
+   *     || initializationVector (Uint8Array) (12 bytes)
    *     || encryptedDataLengthInBytes (BigUint64)
-   *     || encryptedData (Buffer)
-   *     || dataAuthenticationTag (Buffer) (16 bytes)
+   *     || encryptedData (Uint8Array)
+   *     || dataAuthenticationTag (Uint8Array) (16 bytes)
    *     || encryptedNonce (32 bytes)
-   *     || nonceAuthenticationTag (Buffer) (16 bytes)
+   *     || nonceAuthenticationTag (Uint8Array) (16 bytes)
    *
    * @internal
    */

--- a/src/engines/x0.ts
+++ b/src/engines/x0.ts
@@ -29,60 +29,44 @@ export class EncryptionResult {
    * Ciphertext buffer
    * @internal
    */
-  _ciphertext: Buffer;
+  _ciphertext: Uint8Array;
 
   /**
    * Wrapper key id buffer
    * @internal
    */
-  _wrapperKeyId: Buffer;
+  _wrapperKeyId: Uint8Array;
 
   /**
    * Constructor
    * @internal
    */
-  constructor(ciphertext: Buffer, wrapperKeyId: Buffer) {
+  constructor(ciphertext: Uint8Array, wrapperKeyId: Uint8Array) {
     this._ciphertext = ciphertext;
     this._wrapperKeyId = wrapperKeyId;
   }
 
   /**
    * Returns the ciphertext.
-   *
-   * @param {BufferEncoding} [encoding] - Optional encoding which converts the ciphertext to a string using the given encoding.
    */
-  ciphertext(): Buffer;
-  ciphertext(encoding: BufferEncoding): string;
-  ciphertext(encoding?: BufferEncoding) {
-    if (encoding !== undefined) {
-      return this._ciphertext.toString(encoding);
-    } else {
-      return this._ciphertext;
-    }
+  ciphertext(): Uint8Array {
+    return this._ciphertext;
   }
 
   /**
    * Returns the wrapper key id.
-   *
-   * @param {BufferEncoding} [encoding] - Optional encoding which converts the wrapper key id to a string using the given encoding.
    */
-  wrapperKeyId(): Buffer;
-  wrapperKeyId(encoding: BufferEncoding): string;
-  wrapperKeyId(encoding?: BufferEncoding) {
-    if (encoding !== undefined) {
-      return this._wrapperKeyId.toString(encoding);
-    } else {
-      return this._wrapperKeyId;
-    }
+  wrapperKeyId(): Uint8Array {
+    return this._wrapperKeyId;
   }
 }
 
 export interface EncryptConfig {
   // The wrapper key (RSA public key in PEM format).
-  wrapperKey: Buffer;
+  wrapperKey: string;
 
   // The metadata ID of the RSA public key.
-  wrapperKeyId: Buffer;
+  wrapperKeyId: Uint8Array;
 }
 
 export class Encryption {
@@ -90,7 +74,7 @@ export class Encryption {
    * Plaintext buffer
    * @internal
    */
-  _plaintext: Buffer;
+  _plaintext: Uint8Array;
 
   /**
    * Config object
@@ -101,12 +85,12 @@ export class Encryption {
   /**
    * Instantiates a new Encryption instance.
    *
-   * @param {Buffer} plaintext - The plaintext data to encrypt.
+   * @param plaintext - The plaintext data to encrypt.
    * @param {EncryptConfig} config - An object to configure encryption.
    *   * wrapperKey - (Buffer) The wrapper key (RSA public key in PEM format).
    *   * wrapperKeyId - (Buffer) The metadata ID of the RSA public key.
    */
-  constructor(plaintext: Buffer, config: EncryptConfig) {
+  constructor(plaintext: Uint8Array, config: EncryptConfig) {
     this._plaintext = plaintext;
     this._config = config;
   }
@@ -128,12 +112,12 @@ export class Encryption {
    * @internal
    */
   _serialize(
-    ciphertext: Buffer,
-    encryptedDataKey: Buffer,
-    authenticationTag: Buffer,
-    initializationVector: Buffer,
-    wrapperKeyId: Buffer,
-  ): Buffer {
+    ciphertext: Uint8Array,
+    encryptedDataKey: Uint8Array,
+    authenticationTag: Uint8Array,
+    initializationVector: Uint8Array,
+    wrapperKeyId: Uint8Array,
+  ): Uint8Array {
     return concatBuffers(
       cryptoVersionToBuffer(CryptoVersion.x0),
       bufferFromUInt64(wrapperKeyId.length),
@@ -209,29 +193,21 @@ export class DecryptionResult {
    * Plaintext buffer
    * @internal
    */
-  _plaintext: Buffer;
+  _plaintext: Uint8Array;
 
   /**
    * Constructor
    * @internal
    */
-  constructor(plaintext: Buffer) {
+  constructor(plaintext: Uint8Array) {
     this._plaintext = plaintext;
   }
 
   /**
    * Returns the plaintext.
-   *
-   * @param {BufferEncoding} [encoding] - Optional encoding which converts the plaintext to a string using the given encoding.
    */
-  plaintext(): Buffer;
-  plaintext(encoding: BufferEncoding): string;
-  plaintext(encoding?: BufferEncoding) {
-    if (encoding !== undefined) {
-      return this._plaintext.toString(encoding);
-    } else {
-      return this._plaintext;
-    }
+  plaintext(): Uint8Array {
+    return this._plaintext;
   }
 }
 
@@ -240,38 +216,38 @@ export class Decryption {
    * Wrapper key id buffer
    * @internal
    */
-  _wrapperKeyId: Buffer;
+  _wrapperKeyId: Uint8Array;
 
   /**
    * Encrypted data key buffer
    * @internal
    */
-  _encryptedDataKey: Buffer;
+  _encryptedDataKey: Uint8Array;
 
   /**
    * Initialization vector buffer
    * @internal
    */
-  _initializationVector: Buffer;
+  _initializationVector: Uint8Array;
 
   /**
    * Ciphertext buffer
    * @internal
    */
-  _ciphertext: Buffer;
+  _ciphertext: Uint8Array;
 
   /**
    * Authentication tag buffer
    * @internal
    */
-  _authenticationTag: Buffer;
+  _authenticationTag: Uint8Array;
 
   /**
    * Instantiates a new Decryption instance.
    *
-   * @param {Buffer} serialized - The serialized encrypted data to decrypt.
+   * @param serialized - The serialized encrypted data to decrypt.
    */
-  constructor(serialized: Buffer) {
+  constructor(serialized: Uint8Array) {
     const {
       cryptoVersion,
       wrapperKeyId,
@@ -306,7 +282,7 @@ export class Decryption {
    * Deserialize the encrypted data components
    * @internal
    */
-  _deserializeEncryptedData(serializedEncryptedData: Buffer) {
+  _deserializeEncryptedData(serializedEncryptedData: Uint8Array) {
     const cryptoVersion = cryptoVersionFromBuffer(serializedEncryptedData);
 
     let offset = CRYPTO_VERSION_LENGTH_IN_BYTES;
@@ -363,32 +339,16 @@ export class Decryption {
 
   /**
    * Returns the wrapper key id.
-   *
-   * @param {BufferEncoding} [encoding] - Optional encoding which converts the wrapper key id to a string using the given encoding.
    */
-  wrapperKeyId(): Buffer;
-  wrapperKeyId(encoding: BufferEncoding): string;
-  wrapperKeyId(encoding?: BufferEncoding) {
-    if (encoding !== undefined) {
-      return this._wrapperKeyId.toString(encoding);
-    } else {
-      return this._wrapperKeyId;
-    }
+  wrapperKeyId(): Uint8Array {
+    return this._wrapperKeyId;
   }
 
   /**
    * Returns the encrypted data key.
-   *
-   * @param {BufferEncoding} [encoding] - Optional encoding which converts the encrypted data key to a string using the given encoding.
    */
-  encryptedDataKey(): Buffer;
-  encryptedDataKey(encoding: BufferEncoding): string;
-  encryptedDataKey(encoding?: BufferEncoding) {
-    if (encoding !== undefined) {
-      return this._encryptedDataKey.toString(encoding);
-    } else {
-      return this._encryptedDataKey;
-    }
+  encryptedDataKey(): Uint8Array {
+    return this._encryptedDataKey;
   }
 
   /**
@@ -397,7 +357,7 @@ export class Decryption {
    * @param {Buffer} dataKey - The secret key used to encrypt the data.
    * @returns DecryptionResult containing the plaintext data
    */
-  async decrypt(dataKey: Buffer): Promise<DecryptionResult> {
+  async decrypt(dataKey: Uint8Array): Promise<DecryptionResult> {
     try {
       const plaintext = aes256gcmDecrypt(
         this._ciphertext,

--- a/src/version.ts
+++ b/src/version.ts
@@ -12,9 +12,13 @@ export enum CryptoVersion {
   x0 = 0x0000,
 }
 
-export function cryptoVersionFromBuffer(serialized: Buffer): CryptoVersion {
-  const versionBuffer = serialized.slice(0, CRYPTO_VERSION_LENGTH_IN_BYTES);
-  const version = versionBuffer.readUInt16BE();
+export function cryptoVersionFromBuffer(serialized: Uint8Array): CryptoVersion {
+  const versionDataView = new DataView(
+    serialized.buffer,
+    serialized.byteOffset,
+    serialized.byteLength,
+  );
+  const version = versionDataView.getUint16(0, false); // Big endian.
 
   switch (version) {
     case CryptoVersion.x0:
@@ -24,8 +28,8 @@ export function cryptoVersionFromBuffer(serialized: Buffer): CryptoVersion {
   }
 }
 
-export function cryptoVersionToBuffer(version: CryptoVersion): Buffer {
-  const cryptoVersionBuffer = Buffer.alloc(CRYPTO_VERSION_LENGTH_IN_BYTES);
-  cryptoVersionBuffer.writeUInt16BE(version);
-  return cryptoVersionBuffer;
+export function cryptoVersionToBuffer(version: CryptoVersion): Uint8Array {
+  const cryptoVersionBuffer = new ArrayBuffer(CRYPTO_VERSION_LENGTH_IN_BYTES);
+  new DataView(cryptoVersionBuffer).setUint16(0, version, false); // Big endian.
+  return new Uint8Array(cryptoVersionBuffer);
 }

--- a/src/webcrypto.d.ts
+++ b/src/webcrypto.d.ts
@@ -1,1 +1,3 @@
-declare module 'webcrypto';
+declare module 'webcrypto' {
+  export * from 'node:crypto';
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,12 +1,13 @@
 import {CryptoEngine, CryptoVersion} from '../src';
 import crypto from 'crypto';
+import {Buffer} from 'node:buffer';
 
 describe('x0', () => {
   const x0 = CryptoEngine(CryptoVersion.x0);
 
   const wrapperKeyId = Buffer.from('8ebdc958-f2cb-47c6-a6a4-a083e6ce1fb2');
 
-  let publicKey: Buffer;
+  let publicKey: string;
   let privateKey: crypto.KeyObject;
 
   beforeAll(function () {
@@ -15,11 +16,10 @@ describe('x0', () => {
     });
 
     // The privy API sends the public key as a base64-encoded PEM string
-    const pem = keys.publicKey.export({
+    publicKey = keys.publicKey.export({
       type: 'spki',
       format: 'pem',
-    });
-    publicKey = Buffer.from(pem);
+    }) as string;
 
     privateKey = keys.privateKey;
   });
@@ -41,7 +41,7 @@ describe('x0', () => {
     expect(encryptionResult.wrapperKeyId()).toEqual(wrapperKeyId);
 
     const privyDecryption = new x0.Decryption(ciphertext);
-    expect(privyDecryption.wrapperKeyId()).toEqual(wrapperKeyId);
+    expect(Buffer.from(privyDecryption.wrapperKeyId())).toEqual(wrapperKeyId);
 
     const decryptedDataKey = crypto.privateDecrypt(
       {
@@ -52,6 +52,7 @@ describe('x0', () => {
     );
 
     const decryptionResult = await privyDecryption.decrypt(decryptedDataKey);
-    expect(decryptionResult.plaintext('utf8')).toEqual('{"ssn": "123-45-6789"}');
+    const plaintextResult = Buffer.from(decryptionResult.plaintext()).toString('utf8');
+    expect(plaintextResult).toEqual('{"ssn": "123-45-6789"}');
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,7 +38,7 @@ describe('x0', () => {
 
     const encryptionResult = await privyEncryption.encrypt();
     const ciphertext = encryptionResult.ciphertext();
-    const commitmentHash = encryptionResult.commitmentHash('hex');
+    const commitmentHash = encryptionResult.commitmentHash();
     expect(encryptionResult.wrapperKeyId()).toEqual(wrapperKeyId);
 
     const privyDecryption = new x0.Decryption(ciphertext);
@@ -52,10 +52,7 @@ describe('x0', () => {
       privyDecryption.encryptedDataKey(),
     );
 
-    const decryptionResult = await privyDecryption.decrypt(
-      decryptedDataKey,
-      Buffer.from(commitmentHash, 'hex'),
-    );
+    const decryptionResult = await privyDecryption.decrypt(decryptedDataKey, commitmentHash);
     const plaintextResult = Buffer.from(decryptionResult.plaintext()).toString('utf8');
     expect(plaintextResult).toEqual('{"ssn": "123-45-6789"}');
   });


### PR DESCRIPTION
This removes all the direct usages of Buffer from the library code. `crypto-browserify` still pulls in a buffer dependency, so this doesn't change much about the resulting dependency tree, but it allows us to avoid the requirement to provide a Buffer when using this library. We also still use the convenience functions from Buffer in the tests.

Generally this was a smooth conversion, although there is a hack necessary to use md5 hashes in the browser.

This is a breaking change and will require changes to privy-js and a major version bump before it can be published.

I've tested against a locally updated privy-js branch with privy-pii-demo (browser env) and privy-client-tester (Node env).